### PR TITLE
feat: show aliases in command help page

### DIFF
--- a/src/iccli/cmd/cmd_aws/cmd_group.py
+++ b/src/iccli/cmd/cmd_aws/cmd_group.py
@@ -42,13 +42,13 @@ class AliasedGroup(click.Group):
 
         sub_commands = self.list_commands(ctx)
 
-        limit = formatter.width - 6 - max(len(cmd[0]) for cmd in sub_commands)
+        limit = formatter.width - 6 - max(len(sub_cmd[0]) for sub_cmd in sub_commands)
 
         for sub_command in sub_commands:
-            cmd = self.get_command(ctx, sub_command)
-            if cmd is None:
+            command = self.get_command(ctx, sub_command)
+            if command is None:
                 continue
-            if hasattr(cmd, 'hidden') and cmd.hidden:
+            if hasattr(command, 'hidden') and command.hidden:
                 continue
 
             inverted_aliases = dict()
@@ -59,7 +59,7 @@ class AliasedGroup(click.Group):
                 vals = inverted_aliases[sub_command]
                 sub_command = f'{sub_command} {{{", ".join(vals)}}}'
 
-            cmd_help = cmd.get_short_help_str(limit)
+            cmd_help = command.get_short_help_str(limit)
 
             rows.append((sub_command, cmd_help))
 


### PR DESCRIPTION
Currently, aliases are not showed in the CLI help.
This can be confusing for users seeing for example "ic aws up" in the documentation and then doing the command "ic aws --help" which does not show the command "up".

I've added the ability to see aliases:
![PangoBright_NoormbbGAB](https://user-images.githubusercontent.com/23641464/64078168-48872f80-cca5-11e9-8df1-0eb8d6043358.png)